### PR TITLE
Dhcp proxy sase-service implementation

### DIFF
--- a/plugins/sase/common/pod.go
+++ b/plugins/sase/common/pod.go
@@ -66,6 +66,7 @@ type PodInfo struct {
 	Label       string // Microservice Label
 	Interfaces  []PodInterfaceInfo
 	ServiceList []PodSaseServiceInfo
+	IPAddress   string
 }
 
 // InterfaceMode : Operating mode of Interface

--- a/plugins/sase/common/service.go
+++ b/plugins/sase/common/service.go
@@ -30,6 +30,8 @@ const (
 	ServiceTypeRouting
 	// ServiceTypeIPSecVpn :
 	ServiceTypeIPSecVpn // Change to just VPN
+	//ServiceTypeDhcpProxy
+	ServiceTypeDhcpProxy
 )
 
 const (
@@ -41,6 +43,8 @@ const (
 	routing = "routing"
 	// IpsecVpn :
 	ipsecVpn = "ipsecvpn"
+	// Dhcp Proxy:
+	dhcpProxy = "dhcpproxy"
 )
 
 const (
@@ -71,7 +75,11 @@ func GetBaseVppServices() []PodSaseServiceInfo {
 			serviceType:     nat},
 		{serviceID: baseServiceID,
 			serviceLocation: baseServiceLocation,
-			serviceType:     ipsecVpn}}
+			serviceType:     ipsecVpn},
+		{serviceID: baseServiceID,
+			serviceLocation: baseServiceLocation,
+			serviceType:     dhcpProxy},
+	}
 
 	return addService
 }
@@ -95,6 +103,8 @@ func (srv *ServiceInfo) GetServiceType() SaseServiceType {
 		serviceType = ServiceTypeRouting
 	case ipsecVpn:
 		serviceType = ServiceTypeIPSecVpn
+	case dhcpProxy:
+		serviceType = ServiceTypeDhcpProxy
 	default:
 	}
 

--- a/plugins/sase/processor/processor_impl.go
+++ b/plugins/sase/processor/processor_impl.go
@@ -1203,6 +1203,15 @@ func (sp *SaseServiceProcessor) processServiceDeletion(podID podmodel.ID, delSer
 			// De-Init service
 			sp.renderers[serviceType].DeInit()
 
+			sp.Log.Info("processServiceDeletion: Render ", sp.services[s].Name, "service Delete")
+			// Delete service
+			// Fill in the relevant information
+			p := &config.SaseServiceConfig{
+				ServiceInfo: sp.services[s],
+				Config:      sp.services[s].Pod,
+			}
+			_ = sp.renderers[serviceType].DeleteServiceConfig(p)
+
 			sp.Log.Info("processServiceDeletion: Delete Service from services list")
 			// Delete Service from the service cache
 			delete(sp.services, s)

--- a/plugins/sase/processor/processor_impl.go
+++ b/plugins/sase/processor/processor_impl.go
@@ -473,7 +473,6 @@ func (sp *SaseServiceProcessor) ProcessDeletedNetworkFirewallProfileConfig(cfg *
 	return err
 }
 
-
 //////////////////////////////// Site Resource Group Processor Routines ////////////////////////
 
 // ProcessNewSiteResourceConfig :
@@ -953,7 +952,6 @@ func (sp *SaseServiceProcessor) ProcessDeletedSaseServiceInterfaceConfig(cfg *sa
 	return err
 }
 
-
 /////////////////////////// Pod Events ////////////////////////////////////////////
 
 // GetPodInfo : Get PodInfo for given pidId
@@ -1026,8 +1024,9 @@ func (sp *SaseServiceProcessor) ProcessUpdatedPod(pod *podmodel.Pod) error {
 			return nil
 		}
 		podInfo := &common.PodInfo{
-			ID:    podID,
-			Label: label,
+			ID:        podID,
+			Label:     label,
+			IPAddress: pod.IpAddress,
 		}
 		// Add PodInfo to the podlist
 		sp.AddPodInfo(podID, podInfo)
@@ -1051,6 +1050,7 @@ func (sp *SaseServiceProcessor) ProcessUpdatedPod(pod *podmodel.Pod) error {
 	if common.HasSaseServicesAnnotation(pod.Annotations) == true {
 		var saseServiceList []common.PodSaseServiceInfo
 		saseServices := common.GetSaseServices(pod.Annotations)
+		sp.Log.Info("New/ Updated pod: saseServices %v", saseServices)
 		for _, saseService := range saseServices {
 			saseServiceInfo, _ := common.ParseSaseServiceName(saseService)
 			sp.Log.Infof("New / Updated pod: SaseServiceInfo %v", saseServiceInfo)
@@ -1173,6 +1173,16 @@ func (sp *SaseServiceProcessor) processServiceAddition(podID podmodel.ID, addSer
 		sp.Log.Info("processServiceAddition: Render ", service.Name, "service Init")
 		// Init Service
 		sp.renderers[serviceType].Init()
+
+		sp.Log.Info("processServiceAddition: Render ", service.Name, "service Add")
+		// Add service
+		// Fill in the relevant information
+		p := &config.SaseServiceConfig{
+			ServiceInfo: service,
+			Config:      podInfo,
+		}
+		err = sp.renderers[serviceType].AddServiceConfig(p, false)
+		return err
 	}
 	return nil
 }

--- a/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer.go
+++ b/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer.go
@@ -1,0 +1,213 @@
+/*
+ * // Copyright (c) 2017 Cisco and/or its affiliates.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at:
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package dhcpproxy
+
+import (
+	//"errors"
+
+	"fmt"
+
+	"github.com/contiv/vpp/plugins/contivconf"
+	controller "github.com/contiv/vpp/plugins/controller/api"
+	"github.com/contiv/vpp/plugins/ipam"
+	"github.com/contiv/vpp/plugins/ipnet"
+	"github.com/contiv/vpp/plugins/nodesync"
+	"github.com/contiv/vpp/plugins/sase/common"
+	"github.com/contiv/vpp/plugins/sase/config"
+	"github.com/contiv/vpp/plugins/sase/renderer"
+	"github.com/contiv/vpp/plugins/statscollector"
+	"go.ligato.io/cn-infra/v2/logging"
+	vpp_l3 "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/l3"
+)
+
+// Renderer implements rendering of dhcp proxy settings
+type Renderer struct {
+	Deps
+}
+
+// Deps lists dependencies of the Renderer.
+type Deps struct {
+	Log              logging.Logger
+	Config           *config.SaseServiceConfig
+	ContivConf       contivconf.API
+	IPAM             ipam.API
+	IPNet            ipnet.API
+	UpdateTxnFactory func(change string) (txn controller.UpdateOperations)
+	ResyncTxnFactory func() (txn controller.ResyncOperations)
+	Stats            statscollector.API /* used for exporting the statistics */
+	RemoteDB         nodesync.KVDBWithAtomic
+	MockTest         bool
+}
+
+// Init initializes the renderer.
+func (rndr *Renderer) Init() error {
+	rndr.Log.Infof("Dhcp proxy service: Renderer Init")
+	return nil
+}
+
+// DeInit clean up service config
+func (rndr *Renderer) DeInit() error {
+	return nil
+}
+
+// AfterInit starts cleanup.
+func (rndr *Renderer) AfterInit() error {
+	return nil
+}
+
+// AddServiceConfig :
+func (rndr *Renderer) AddServiceConfig(sp *config.SaseServiceConfig, reSync bool) error {
+
+	rndr.Log.Infof("Dhcp proxy service: Renderer AddServiceConfig %v %+v", sp, sp.Config)
+	// We do not have a proto model for dhcp proxy service. This service internally derives the proxy
+	// configuration from the POD and VPP Lan interface IP addresses.
+	return rndr.CreateDhcpProxy(sp.ServiceInfo, sp.Config.(*common.PodInfo), reSync)
+}
+
+// UpdateServiceConfig :
+func (rndr *Renderer) UpdateServiceConfig(old, new *config.SaseServiceConfig) error {
+
+	// Check for service config type
+	switch new.Config.(type) {
+	case *common.PodInfo:
+		return rndr.UpdateDhcpProxy(new.ServiceInfo, old.Config.(*common.PodInfo), new.Config.(*common.PodInfo))
+	default:
+	}
+	return nil
+}
+
+// DeleteServiceConfig :
+func (rndr *Renderer) DeleteServiceConfig(sp *config.SaseServiceConfig) error {
+	// Check for service config type
+	switch sp.Config.(type) {
+	case *common.PodInfo:
+		return rndr.DeleteDhcpProxy(sp.ServiceInfo, sp.Config.(*common.PodInfo))
+	default:
+	}
+	return nil
+}
+
+/////////////////////////// Dhcp Proxy Related ////////////////
+
+// CreateDhcpProxy adds new dhcp proxy server for a given source IP
+func (rndr *Renderer) CreateDhcpProxy(serviceInfo *common.ServiceInfo, pod *common.PodInfo, reSync bool) error {
+
+	rndr.Log.Infof("Dhcp proxy service: CreateDhcpProxy: ServiceInfo %v", serviceInfo, "PodInfo: %v", serviceInfo, pod)
+	// Render dhcp proxy vpp proto buf
+	ipAddrPool := rndr.GetVppLanInterfaceIPAddress(serviceInfo, "lan")
+
+	dhcp_server := vpp_l3.DHCPProxy_DHCPServer{
+		VrfId:     1,
+		IpAddress: pod.IPAddress,
+	}
+	dhcp_proxy := vpp_l3.DHCPProxy{
+		SourceIpAddress: ipAddrPool[0],
+		RxVrfId:         0,
+	}
+	dhcp_proxy.Servers = append(dhcp_proxy.Servers, &dhcp_server)
+
+	// Test Purpose
+	if rndr.MockTest {
+		return renderer.MockCommit(serviceInfo.GetServicePodLabel(), vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy, config.Add)
+	}
+
+	// Commit is for local base vpp vswitch
+	rndr.Log.Info(" DhcpProxy service: CreateDhcpProxy:  Post txn to local vpp agent",
+		"Key: %s", "Value: %v", dhcp_proxy.SourceIpAddress, dhcp_proxy)
+	if reSync == true {
+		txn := rndr.ResyncTxnFactory()
+		txn.Put(vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy)
+	} else {
+		txn := rndr.UpdateTxnFactory(fmt.Sprintf("Dhcp Proxy Service %s", vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress)))
+		txn.Put(vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy)
+	}
+	// TODO - should be committed to KVSDB. We run the dhcp proxy only on base vpp.
+	//return renderer.Commit(rndr.RemoteDB, serviceInfo.GetServicePodLabel(), vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy, config.Add)
+	return nil
+}
+
+// UpdateDhcpProxy updates existing dhcp proxy settings
+func (rndr *Renderer) UpdateDhcpProxy(serviceInfo *common.ServiceInfo, old, new *common.PodInfo) error {
+
+	rndr.Log.Infof("UpdateDhcpProxy: %v", new)
+	return nil
+}
+
+// DeleteDhcpProxy deletes an existing dhcp proxy setting
+func (rndr *Renderer) DeleteDhcpProxy(serviceInfo *common.ServiceInfo, pod *common.PodInfo) error {
+
+	rndr.Log.Infof("Dhcp Proxy Service: DeleteDhcpProxy: ServiceInfo %v", serviceInfo, "PodInfo: %v", sp)
+
+	// Render dhcp proxy vpp proto buf
+	ipAddrPool := rndr.GetVppLanInterfaceIPAddress(serviceInfo, "lan")
+
+	dhcp_server := vpp_l3.DHCPProxy_DHCPServer{
+		VrfId:     1,
+		IpAddress: pod.IPAddress,
+	}
+	dhcp_proxy := vpp_l3.DHCPProxy{
+		SourceIpAddress: ipAddrPool[0],
+		RxVrfId:         0,
+	}
+	dhcp_proxy.Servers = append(dhcp_proxy.Servers, &dhcp_server)
+
+	// Test Purpose
+	if rndr.MockTest {
+		return renderer.MockCommit(serviceInfo.GetServicePodLabel(), vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy, config.Delete)
+	}
+
+	// Commit is for local base vpp vswitch
+	rndr.Log.Info(" DhcpProxy service: CreateDhcpProxy:  Post txn to local vpp agent",
+		"Key: %s", "Value: %v", dhcp_proxy.SourceIpAddress, dhcp_proxy)
+
+	txn := rndr.UpdateTxnFactory(fmt.Sprintf("Dhcp Proxy Service %s", vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress)))
+	txn.Delete(vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress))
+
+	// TODO - should be committed to KVSDB. We run the dhcp proxy only on base vpp.
+	//return renderer.Commit(rndr.RemoteDB, serviceInfo.GetServicePodLabel(), vpp_l3.DHCPProxyKey(dhcp_proxy.SourceIpAddress), &dhcp_proxy, config.Delete)
+	return nil
+}
+
+// GetVppLanInterfaceIPAddress: Return primary IP Address for a given Interface
+func (rndr *Renderer) GetVppLanInterfaceIPAddress(serviceInfo *common.ServiceInfo, interfaceName string) []string {
+
+	var ipAddrPool []string
+
+	// Check Main VPP Interfaces
+	if rndr.ContivConf.GetMainInterfaceName() == interfaceName {
+		ipWithNetworks := rndr.ContivConf.GetMainInterfaceConfiguredIPs()
+		rndr.Log.Info("GetVppLanInterfaceIPAddress: ipWithNetworks for MainVPPInterface: ", ipWithNetworks)
+		for _, ipNet := range ipWithNetworks {
+			// Add the Addresses associated with Main Interface to address pool
+			ipAddrPool = append(ipAddrPool, ipNet.Address.String())
+		}
+		return ipAddrPool
+	}
+
+	// Check Other VPP Interfaces
+	otherVppInterfaces := rndr.ContivConf.GetOtherVPPInterfaces()
+	rndr.Log.Info("GetInterfaceNameWithIP: otherVppInterfaces: ", otherVppInterfaces)
+	for _, oVppIntf := range otherVppInterfaces {
+		if oVppIntf.InterfaceName == interfaceName {
+			for _, ipNet := range oVppIntf.IPs {
+				ipAddrPool = append(ipAddrPool, ipNet.Address.String())
+			}
+			return ipAddrPool
+		}
+	}
+	return ipAddrPool
+}

--- a/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer.go
+++ b/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer.go
@@ -150,7 +150,7 @@ func (rndr *Renderer) UpdateDhcpProxy(serviceInfo *common.ServiceInfo, old, new 
 // DeleteDhcpProxy deletes an existing dhcp proxy setting
 func (rndr *Renderer) DeleteDhcpProxy(serviceInfo *common.ServiceInfo, pod *common.PodInfo) error {
 
-	rndr.Log.Infof("Dhcp Proxy Service: DeleteDhcpProxy: ServiceInfo %v", serviceInfo, "PodInfo: %v", sp)
+	rndr.Log.Infof("Dhcp Proxy Service: DeleteDhcpProxy: ServiceInfo %v", serviceInfo, "PodInfo: %v", pod)
 
 	// Render dhcp proxy vpp proto buf
 	ipAddrPool := rndr.GetVppLanInterfaceIPAddress(serviceInfo, "lan")

--- a/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer_test.go
+++ b/plugins/sase/renderer/dhcp_proxy/dhcp_proxy_renderer_test.go
@@ -1,0 +1,17 @@
+/*
+ * // Copyright (c) 2018 Cisco and/or its affiliates.
+ * //
+ * // Licensed under the Apache License, Version 2.0 (the "License");
+ * // you may not use this file except in compliance with the License.
+ * // You may obtain a copy of the License at:
+ * //
+ * //     http://www.apache.org/licenses/LICENSE-2.0
+ * //
+ * // Unless required by applicable law or agreed to in writing, software
+ * // distributed under the License is distributed on an "AS IS" BASIS,
+ * // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * // See the License for the specific language governing permissions and
+ * // limitations under the License.
+ */
+
+package dhcpproxy

--- a/plugins/sase/renderer/firewall/fw_renderer.go
+++ b/plugins/sase/renderer/firewall/fw_renderer.go
@@ -98,7 +98,7 @@ func (rndr *Renderer) UpdateServiceConfig(old, new *config.SaseServiceConfig) er
 		return rndr.UpdateSaseConfig(new.ServiceInfo,
 			old.Config.(*sasemodel.SaseConfig), new.Config.(*sasemodel.SaseConfig))
 	case *sasemodel.NetworkFirewallProfile:
-		return rndr.UpdateNetworkFirewallProfile(new.ServiceInfo, 
+		return rndr.UpdateNetworkFirewallProfile(new.ServiceInfo,
 			old.Config.(*sasemodel.NetworkFirewallProfile), new.Config.(*sasemodel.NetworkFirewallProfile))
 	default:
 	}
@@ -150,7 +150,7 @@ func getNfpActionFromSaseAction(act sasemodel.SaseConfig_Action) sasemodel.Netwo
 	return nfpAct
 }
 
-func getNfpProtocolFromSaseProtocol(proto sasemodel.SaseConfig_Match_Proto) sasemodel.NetworkFirewallProfile_FirewallRule_Proto{
+func getNfpProtocolFromSaseProtocol(proto sasemodel.SaseConfig_Match_Proto) sasemodel.NetworkFirewallProfile_FirewallRule_Proto {
 
 	var nfpProto sasemodel.NetworkFirewallProfile_FirewallRule_Proto
 
@@ -168,13 +168,13 @@ func getNfpProtocolFromSaseProtocol(proto sasemodel.SaseConfig_Match_Proto) sase
 func getNfpRuleFromSaseConfigMatchAction(m *sasemodel.SaseConfig_Match, a sasemodel.SaseConfig_Action) *sasemodel.NetworkFirewallProfile_FirewallRule {
 
 	// Get the network firewall rule
-	rule := &sasemodel.NetworkFirewallProfile_FirewallRule {
-		Protocol: getNfpProtocolFromSaseProtocol(m.Protocol),
-		SrcProtoPort: 0,
-		DstProtoPort: m.ProtocolPort,
-		SourceCidr: m.SourceIp,
+	rule := &sasemodel.NetworkFirewallProfile_FirewallRule{
+		Protocol:        getNfpProtocolFromSaseProtocol(m.Protocol),
+		SrcProtoPort:    0,
+		DstProtoPort:    m.ProtocolPort,
+		SourceCidr:      m.SourceIp,
 		DestinationCidr: m.DestinationIp,
-		Action: getNfpActionFromSaseAction(a),
+		Action:          getNfpActionFromSaseAction(a),
 	}
 	return rule
 }
@@ -183,9 +183,9 @@ func getNfpRuleFromSaseConfigMatchAction(m *sasemodel.SaseConfig_Match, a sasemo
 func convertSaseConfigToNetworkFirewallProfile(sp *sasemodel.SaseConfig) *sasemodel.NetworkFirewallProfile {
 
 	nfp := &sasemodel.NetworkFirewallProfile{
-		Name: sp.Name,
+		Name:                sp.Name,
 		ServiceInstanceName: sp.ServiceInstanceName,
-		Direction: getNfpDirectionFromSaseConfigDirection(sp.Direction),
+		Direction:           getNfpDirectionFromSaseConfigDirection(sp.Direction),
 	}
 
 	// Get Nfp Rules
@@ -200,10 +200,10 @@ func convertSaseConfigToNetworkFirewallProfile(sp *sasemodel.SaseConfig) *sasemo
 
 	return nfp
 }
- 
+
 // AddSaseConfig :
 func (rndr *Renderer) AddSaseConfig(serviceInfo *common.ServiceInfo, sp *sasemodel.SaseConfig, reSync bool) error {
-	
+
 	rndr.Log.Infof("Firewall Service: AddSaseConfig: ServiceInfo %v", serviceInfo, "Config: %v", sp)
 
 	// Convert SaseConfig to Network firewall profile
@@ -213,9 +213,9 @@ func (rndr *Renderer) AddSaseConfig(serviceInfo *common.ServiceInfo, sp *sasemod
 
 // UpdateSaseConfig :
 func (rndr *Renderer) UpdateSaseConfig(serviceInfo *common.ServiceInfo, old, new *sasemodel.SaseConfig) error {
-	
+
 	rndr.Log.Infof("Firewall Service: UpdateSaseConfig ServiceInfo %v", serviceInfo, "New Config: %v", new,
-		 "Old Config: %v", old)
+		"Old Config: %v", old)
 
 	oldNfp := convertSaseConfigToNetworkFirewallProfile(old)
 	newNfp := convertSaseConfigToNetworkFirewallProfile(new)
@@ -224,7 +224,7 @@ func (rndr *Renderer) UpdateSaseConfig(serviceInfo *common.ServiceInfo, old, new
 
 // DeleteSaseConfig :
 func (rndr *Renderer) DeleteSaseConfig(serviceInfo *common.ServiceInfo, sp *sasemodel.SaseConfig) error {
-	
+
 	rndr.Log.Infof("Firewall Service: DeleteSaseConfig: ServiceInfo %v", serviceInfo, "Config: %v", sp)
 
 	nfp := convertSaseConfigToNetworkFirewallProfile(sp)
@@ -233,7 +233,7 @@ func (rndr *Renderer) DeleteSaseConfig(serviceInfo *common.ServiceInfo, sp *sase
 
 // CreateNetworkFirewallProfile adds New Network firewall Profile
 func (rndr *Renderer) CreateNetworkFirewallProfile(serviceInfo *common.ServiceInfo, sp *sasemodel.NetworkFirewallProfile, reSync bool) error {
-	
+
 	rndr.Log.Infof("Firewall Service: CreateNetworkFirewallProfile: ServiceInfo %v", serviceInfo, "Profile: %v", sp)
 
 	// Render ACL Rules
@@ -279,7 +279,7 @@ func (rndr *Renderer) CreateNetworkFirewallProfile(serviceInfo *common.ServiceIn
 
 // UpdateNetworkFirewallProfile updates existing Network Firewall Profile
 func (rndr *Renderer) UpdateNetworkFirewallProfile(serviceInfo *common.ServiceInfo, old, new *sasemodel.NetworkFirewallProfile) error {
-	
+
 	rndr.Log.Infof("UpdateNetworkFirewallProfile: %v", new)
 	return rndr.CreateNetworkFirewallProfile(serviceInfo, new, false)
 }
@@ -361,8 +361,8 @@ func (rndr *Renderer) renderVppACL(profile *sasemodel.NetworkFirewallProfile) *v
 		Name: profile.Name,
 	}
 
-    // Render ACL Rules
-	for _,rule := range profile.Rules {
+	// Render ACL Rules
+	for _, rule := range profile.Rules {
 		aclRule := rndr.renderVppACLRule(rule)
 		acl.Rules = append(acl.Rules, expandAnyAddr(aclRule)...)
 	}
@@ -373,7 +373,7 @@ func (rndr *Renderer) renderVppACLRule(rule *sasemodel.NetworkFirewallProfile_Fi
 	const maxPortNum = ^uint16(0)
 	// VPP ACL Plugin Rule
 	aclRule := &vpp_acl.ACL_Rule{}
-	if rule.Action == sasemodel.NetworkFirewallProfile_FirewallRule_PERMIT_REFLECT{
+	if rule.Action == sasemodel.NetworkFirewallProfile_FirewallRule_PERMIT_REFLECT {
 		aclRule.Action = vpp_acl.ACL_Rule_REFLECT
 	} else {
 		aclRule.Action = vpp_acl.ACL_Rule_DENY
@@ -385,16 +385,16 @@ func (rndr *Renderer) renderVppACLRule(rule *sasemodel.NetworkFirewallProfile_Fi
 	// Get Source and Destination Networks
 	_, ipv4SrcNet, err := net.ParseCIDR(rule.SourceCidr)
 	if err != nil {
-			// Invalid or No Src Network provided in config
-			ipv4SrcNet = nil
+		// Invalid or No Src Network provided in config
+		ipv4SrcNet = nil
 	}
 	_, ipv4DstNet, err := net.ParseCIDR(rule.DestinationCidr)
 	if err != nil {
-			// Invalid or No Dst Network provided in config
-			ipv4DstNet = nil
+		// Invalid or No Dst Network provided in config
+		ipv4DstNet = nil
 	}
 
-	if ipv4SrcNet!= nil && len(ipv4SrcNet.IP) > 0 {
+	if ipv4SrcNet != nil && len(ipv4SrcNet.IP) > 0 {
 		aclRule.IpRule.Ip.SourceNetwork = ipv4SrcNet.String()
 	}
 	if ipv4DstNet != nil && len(ipv4DstNet.IP) > 0 {


### PR DESCRIPTION
Summary -
1. Create a new sase-service to enable dhcp proxy service to punt dhcp frames from lan network to dhcp server IP
2. Create a dhcp pod and run isc-dhcp-service
3. Track POD creation and deletion under sase-plugin. Cache dhcp servic pod IP for proxy configuration.
4. Add/ remove dhcp proxy for lan interface on dhcp service pod add/ delete. Invoke appropriate L3 dhcp proto buf messages for base vpp programming.

Unit testing -
1. Create a dhcp serveer pod. Add dhcproxy sase-service as shown in the yaml below.

```
apiVersion: v1
kind: Pod
metadata:
  name: dhcp-server
  annotations:
    contivpp.io/custom-if: memif1/memif/stub
    contivpp.io/sase-service: 0/sjc/dhcpproxy
  labels:
    cnf: dhcp-server
spec:
  containers:
    - name: vpp-agent
      image: ligato/vpp-agent:latest
      imagePullPolicy: IfNotPresent
      env:
        - name: ETCD_CONFIG
          value: "/etc/etcd/etcd.conf"
        - name: MICROSERVICE_LABEL
          value: vpp-cnf1
        - name: ETCD_EXPAND_ENV_VARS
          value: "true"
      resources:
        limits:
          contivpp.io/memif: 1
      volumeMounts:
        - name: etcd-cfg
          mountPath: /etc/etcd
  volumes:
    - name: etcd-cfg
      configMap:
        name: etcd-cfg
```

2. Apply the yaml
3. Configure dhcp server on the POD. Start the service
4. Verify dhcp proxy is set for src-address = LAN interface IP and server = Dhcp POD IP
5. Verify dhcp proxy configuration is cleaned up when dhcp pod is deleted
6. Create a new VM. Bring-up a internal network interface connected to LAN interface of edge-vm
7. Run dhclient for internal network interface
8. Verify IP address being allocated from the range defined in dhcp server conf file
